### PR TITLE
Basic Yelp API Interaction and Routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data/
 mongod
 coverage/
+bower_components/

--- a/config/express.js
+++ b/config/express.js
@@ -1,14 +1,34 @@
 'use strict'
-
+const YelpAPI = require('./yelp-api');
 /**
  * Expose
  */
 
 module.exports = function(app,passport) {
     
-    app.use('/', (req,res) => {
+    app.get('/', (req,res) => {
         
         res.send(200);
+        
+    });
+    
+    app.get('/api/v1', (req,res) => {
+        
+        res.json({message: 'Here is where the API resides'});
+        
+    });
+    
+    app.get('/api/v1/business', (req,res) => {
+        
+        YelpAPI.getBusiness((err,data) => {
+            
+            if(err) return res.json(err);
+            
+            res.json(data);
+            
+            
+        });
+        
         
     });
     

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,11 @@
+'use strict'
+const path = require('path');
+
+/**
+ * Expose
+ */
+ 
+exports.root = path.join(__dirname, '..');
+exports.yelpID = process.env.yelpID || 'testID';
+exports.yelpSecret = process.env.yelpSecret || 'yelpSecret';
+

--- a/config/yelp-api.js
+++ b/config/yelp-api.js
@@ -1,0 +1,52 @@
+'use strict'
+const http = require('http');
+const bl = require('bl');
+const config = require('./');
+const request = require('request');
+
+const postData = {
+    
+    'client_id': config.yelpID,
+    'client_secret': config.yelpSecret,
+    'grant_type': 'client_credentials'
+    
+};
+
+let TOKEN = '';
+
+function getToken() {
+    
+    request.post({url: 'https://api.yelp.com/oauth2/token', formData: postData}, (err,res,body) => {
+        if(err) return console.warn(err);
+        
+        if(body) {
+            var data = JSON.parse(body);
+            //console.log(data);
+            //console.log(`Received Token: ${data.access_token}`);
+            TOKEN = data.access_token;
+        }
+        
+    });
+    
+}
+
+getToken();
+
+/**
+ * Expose
+ */
+ exports.getBusiness = function(cb) {
+        request.get('https://api.yelp.com/v3/businesses/search?location=97015&term=bar&sort_by=rating', {
+         
+             'auth' : {
+                 'bearer': TOKEN
+            }
+         
+        }, (err,req,body)=>{
+            if(err) return cb(err);
+             
+             cb(null,JSON.parse(body));
+         
+        });
+}  ;
+ 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "main": "server.js",
   "dependencies": {
     "async": "^0.2.10",
+    "bl": "^1.2.1",
+    "bower": "^1.8.0",
     "express": "^3.2.6",
     "mongoose": "^4.9.7",
     "node": "^0.0.0",
-    "passport": "^0.3.2"
+    "passport": "^0.3.2",
+    "request": "^2.81.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Adds a basic functionality to interact with the Yelp API, including
logging in and receiving the access token. This token is requested
once at application start and will not be requested again until
the applicaiton is restarted. The application will currently fetch
bars from Yelp and sort them by rank. Additionally added a few
dependencies for running the application, including request to make
API calls from the YelpAPI service easier.